### PR TITLE
Bugfix/adjust fullscreen delegate

### DIFF
--- a/Native-IMA/Native_IMA/PlayerInterfaceView.swift
+++ b/Native-IMA/Native_IMA/PlayerInterfaceView.swift
@@ -159,6 +159,15 @@ class PlayerInterfaceView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
+    func setConstraintsToSafeArea(safeArea: UILayoutGuide) {
+        // Position PlayerInterfaceView at the center of the safe area
+        self.centerXAnchor.constraint(equalTo: safeArea.centerXAnchor).isActive = true
+        self.centerYAnchor.constraint(equalTo: safeArea.centerYAnchor).isActive = true
+        // Set width and height using the width and height of the safe area
+        self.widthAnchor.constraint(equalTo: safeArea.widthAnchor).isActive = true
+        self.heightAnchor.constraint(equalTo: safeArea.heightAnchor).isActive = true
+    }
+
     // MARK: - View setup
 
     private func setupView() {

--- a/Native-IMA/Native_IMA/PlayerViewController.swift
+++ b/Native-IMA/Native_IMA/PlayerViewController.swift
@@ -369,16 +369,19 @@ extension PlayerViewController: PlayerInterfaceViewDelegate {
 extension PlayerViewController: FullscreenPresentationDelegate {
     func present(viewController: THEOplayerSDK.FullscreenViewController, completion: @escaping () -> Void) {
         self.present(viewController, animated: true) {
-            viewController.view.addSubview(self.theoplayerView)
-            self.theoplayerView.setConstraintsToSafeArea(safeArea: viewController.view.safeAreaLayoutGuide)
+            viewController.view.addSubview(self.playerInterfaceView)
+            self.playerInterfaceView.setConstraintsToSafeArea(safeArea: viewController.view.safeAreaLayoutGuide)
             completion()
         }
     }
 
     func dismiss(viewController: THEOplayerSDK.FullscreenViewController, completion: @escaping () -> Void) {
         viewController.presentingViewController?.dismiss(animated: false) {
-            self.view.addSubview(self.theoplayerView)
-            self.theoplayerView.setConstraintsToSafeArea(safeArea: self.view.safeAreaLayoutGuide)
+            self.theoplayerView.insertSubview(self.playerInterfaceView, at: self.theoplayerView.subviews.count)
+            self.playerInterfaceView.leadingAnchor.constraint(equalTo: self.theoplayerView.leadingAnchor).isActive = true
+            self.playerInterfaceView.trailingAnchor.constraint(equalTo: self.theoplayerView.trailingAnchor).isActive = true
+            self.playerInterfaceView.topAnchor.constraint(equalTo: self.theoplayerView.topAnchor).isActive = true
+            self.playerInterfaceView.bottomAnchor.constraint(equalTo: self.theoplayerView.bottomAnchor).isActive = true
             completion()
         }
     }

--- a/Native-IMA/Native_IMA/PlayerViewController.swift
+++ b/Native-IMA/Native_IMA/PlayerViewController.swift
@@ -181,7 +181,6 @@ class PlayerViewController: UIViewController {
     private func setupTheoplayer() {
         // Enable chromeless flag in THEOplayer configuration
         let playerConfig = THEOplayerConfiguration(
-            chromeless: true
             /*,license: "your_license_string"*/
         )
 

--- a/Native-IMA/Podfile
+++ b/Native-IMA/Podfile
@@ -6,7 +6,7 @@ target 'Native_IMA' do
 
   # Pods for Native_IMA
   
-    pod 'THEOplayerSDK-core', '~> 5'
-    pod 'THEOplayer-Integration-GoogleIMA', '~> 5'
+    pod 'THEOplayerSDK-core', '~> 7'
+    pod 'THEOplayer-Integration-GoogleIMA', '~> 7'
     
 end


### PR DESCRIPTION
This PR streamlines the way the `playerInterfaceView` containing the player controls is moved/transitioned together with the player to the fullscreen controller.
Before these changes, `theoplayerView` was moved instead of `playerInterfaceView`.
`theoplayerView` contains both `THEOplayer` and `playerInterfaceView`, but since `THEOplayerSDK.FullscreenViewController` already moves `THEOplayer`, it is not necessary to move all of  `theoplayerView`. These changes ensure that only `playerInterfaceView` is moved.